### PR TITLE
Add travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: groovy
+jdk:
+- openjdk6
+before_script:
+  # if we run on the same box as previous build, make sure target is clean
+  - rm -rf target
+script: ./travis-build.sh
+env:
+  global:
+  - GIT_NAME="Craig Andrews"
+  - GIT_EMAIL="candrews@integralblue.com"
+  # travis encrypt -a env.global 'GRAILS_CENTRAL_USERNAME=myusername'
+  # travis encrypt -a env.global 'GRAILS_CENTRAL_PASSWORD=mypassword'
+  # travis encrypt -a env.global 'GH_TOKEN=token' # get the token from https://github.com/settings/applications
+  # TODO add the 3 "secure" lines created by the preceding "travis encrypt" commands here

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+./grailsw refresh-dependencies --non-interactive
+./grailsw test-app --non-interactive
+./grailsw package-plugin --non-interactive
+./grailsw doc --pdf --non-interactive
+if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_REPO_SLUG == 'grails-plugins/grails-cache' ]]; then
+  if [ -n "$GH_TOKEN" ]; then
+    git config --global user.name "$GIT_NAME"
+    git config --global user.email "$GIT_EMAIL"
+    git config --global credential.helper "store --file=~/.git-credentials"
+    echo "https://$GH_TOKEN:@github.com" > ~/.git-credentials
+    git clone https://${GH_TOKEN}@github.com/$TRAVIS_REPO_SLUG.git -b gh-pages gh-pages --single-branch > /dev/null
+    cd gh-pages
+    git rm -rf .
+    cp -r ../target/docs/. ./
+    git add *
+    git commit -a -m "Updating docs for Travis build: https://travis-ci.org/$TRAVIS_REPO_SLUG/builds/$TRAVIS_BUILD_ID"
+    git push origin HEAD
+    cd ..
+    rm -rf gh-pages
+  else
+    echo "GH_TOKEN not set, so not pushing gh-pages"
+  fi
+  if [ -n "$GRAILS_CENTRAL_USERNAME" ]; then
+    ./grailsw publish-plugin --no-scm --allow-overwrite --non-interactive
+  else
+    echo "GRAILS_CENTRAL_USERNAME not set, so not publishing"
+  fi
+else
+  echo "Not on master branch, so not publishing"
+fi


### PR DESCRIPTION
Add Travis CI. This way, we don't have to worry about failing tests any more :)

If you edit .travis.yml and add the 3 items (GH_TOKEN, GRAILS_CENTRAL_USERNAME, and GRAILS_CENTRAL_PASSWORD) the script will automatically update the gh-pages branch with newly generated docs and publish a new version of the plugin (just does grailsw publish-plugin using the version directly and not modifying it).

I'm using this approach on a few other plugins. It's been a great help.

Make sure to go to https://travis-ci.org/profile/grails-plugins and enable Travis for grails-plugins/grails-cache or this change won't exactly do much :)
