### PR TITLE
Add ServerName to Action Cache Key

### DIFF
--- a/src/java/grails/plugin/cache/web/filter/DefaultWebKeyGenerator.java
+++ b/src/java/grails/plugin/cache/web/filter/DefaultWebKeyGenerator.java
@@ -35,6 +35,7 @@ public class DefaultWebKeyGenerator implements WebKeyGenerator {
 		String uri = WebUtils.getForwardURI(request);
 
 		StringBuilder key = new StringBuilder();
+		key.append(request.getServerName().toLowerCase()).append(':');
 		key.append(request.getMethod().toUpperCase());
 
 		String format = WebUtils.getFormatFromURI(uri);


### PR DESCRIPTION
In some cases its necessary for your page results to vary based on the incoming serverName request. Since the key='' modifier on a controller @Cacheable annotation is ignored essentially (another bug for that). It may be best to actually include the serverName in the cache key as well.
