### PR TITLE
Avoid ClassCastException with Int/Long headers

### DIFF
--- a/src/main/groovy/grails/plugin/cache/web/PageInfo.java
+++ b/src/main/groovy/grails/plugin/cache/web/PageInfo.java
@@ -322,7 +322,9 @@ public class PageInfo implements Serializable {
 	public String getHeader(String headerName) {
 		for (Header<? extends Serializable> header : responseHeaders) {
 			if (header.getName().equals(headerName)) {
-				return header.getValue().toString();
+				if(header.getValue() != null) {
+					return header.getValue().toString();
+				}
 			}
 		}
 		return null;

--- a/src/main/groovy/grails/plugin/cache/web/PageInfo.java
+++ b/src/main/groovy/grails/plugin/cache/web/PageInfo.java
@@ -322,7 +322,7 @@ public class PageInfo implements Serializable {
 	public String getHeader(String headerName) {
 		for (Header<? extends Serializable> header : responseHeaders) {
 			if (header.getName().equals(headerName)) {
-				return (String)header.getValue();
+				return header.getValue().toString();
 			}
 		}
 		return null;


### PR DESCRIPTION
When a Date based header (eg Last Modified) is added to the `PageInfo` it is treated as a `Header<Long>`. Header's `getValue()` method is generically typed - returning `Long` in this case. The former code tried to cast `Long` --> `String` which fails with a `ClassCastException`. The current header types (`String`, `Long`, `Integer`) shouldn't need anything more sophisticated than a `toString()` conversion to avoid this issue.