### PR TITLE
- fixed url-pattern changed in memoryPageFragmentCachingFilter

### DIFF
--- a/src/main/groovy/grails/plugin/cache/CacheGrailsPlugin.groovy
+++ b/src/main/groovy/grails/plugin/cache/CacheGrailsPlugin.groovy
@@ -118,7 +118,7 @@ class CacheGrailsPlugin extends Plugin {
                     keyGenerator = ref('webCacheKeyGenerator')
                     expressionEvaluator = ref('webExpressionEvaluator')
                 }
-                urlPatterns = "*"
+                urlPatterns = "/*"
                 dispatcherTypes = EnumSet.of(DispatcherType.FORWARD, DispatcherType.INCLUDE)
             }
 


### PR DESCRIPTION
fixed url-pattern changed in memoryPageFragmentCachingFilter filter to '/*' due to an exception **Unable to start embedded container; nested exception is java.lang.IllegalArgumentException: Invalid <url-pattern> \* in filter mapping**

In the Web application deployment descriptor, the following syntax is used to define mappings:

A string beginning with a ‘ / ’ character and ending with a ‘ /\* ’ suffix is used for path mapping.
A string beginning with a ‘ *. ’ prefix is used as an extension mapping.
The empty string ("") is a special UR L pattern that exactly maps to the application's context root, i.e., requests of the form http://host:port//. In this case the path info is ’ / ’ and the servlet path and context path is empty string (““).
A string containing only the ’/ ’ character indicates the "default" servlet of the application. In this case the servlet path is the request URI minus the context path and the path info is null.
All other strings are used for exact matches only.

From the [Java Servlet Specification](http://download.oracle.com/otn-pub/jcp/servlet-3.0-fr-eval-oth-JSpec/servlet-3_0-final-spec.pdf):
## **Steps to Reproduce**
1. create app grails 3.x
2. deploy app in [payara-micro](http://www.payara.fish/home)
3. run command `java -jar payara-micro.jar --deploy app.war`

`INFO org.springframework.boot.context.embedded.AnnotationConfigEmbeddedWebApplicationContext - Refreshing org.springframework.boot.context.embedded.AnnotationConfigEmbeddedWebApplicationContext@2aca7d: startup date [Fri May 20 09:55:11 BRT 2016]; root of context hierarchy
INFO org.springframework.boot.context.embedded.FilterRegistrationBean - Mapping filter: 'errorPageFilter' to: [/*]
INFO org.springframework.boot.context.embedded.FilterRegistrationBean - Mapping filter: 'characterEncodingFilter' to urls: [/*]
INFO org.springframework.boot.context.embedded.FilterRegistrationBean - Mapping filter: 'hiddenHttpMethodFilter' to urls: [/*]
INFO org.springframework.boot.context.embedded.FilterRegistrationBean - Mapping filter: 'grailsWebRequestFilter' to urls: [/*]
INFO org.springframework.boot.context.embedded.FilterRegistrationBean - Mapping filter: 'memoryPageFragmentCachingFilter' to urls: [*]
WARN org.springframework.boot.context.embedded.AnnotationConfigEmbeddedWebApplicationContext - Exception encountered during context initialization - cancelling refresh (..)
ERROR org.springframework.boot.SpringApplication - Application startup failed
org.springframework.context.ApplicationContextException: Unable to start embedded container; nested exception is java.lang.IllegalArgumentException: Invalid <url-pattern> * in filter mapping
    at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext.onRefresh(EmbeddedWebApplicationContext.java:133)
    at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:532)
    at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext.refresh(EmbeddedWebApplicationContext.java:118)
    at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:766)
    at org.springframework.boot.SpringApplication.createAndRefreshContext(SpringApplication.java:361)
    at org.springframework.boot.SpringApplication.run(SpringApplication.java:307)
    at grails.boot.GrailsApp.run(GrailsApp.groovy:55)
    at org.springframework.boot.context.web.SpringBootServletInitializer.run(SpringBootServletInitializer.java:149)
    at org.grails.boot.context.web.GrailsAppServletInitializer.createRootApplicationContext(GrailsAppServletInitializer.groovy:57)
    at org.springframework.boot.context.web.SpringBootServletInitializer.onStartup(SpringBootServletInitializer.java:85)
    at org.springframework.web.SpringServletContainerInitializer.onStartup(SpringServletContainerInitializer.java:169)
    at org.apache.catalina.core.StandardContext.callServletContainerInitializers(StandardContext.java:6060)
    at com.sun.enterprise.web.WebModule.callServletContainerInitializers(WebModule.java:774)
    at org.apache.catalina.core.StandardContext.start(StandardContext.java:5962)
    at com.sun.enterprise.web.WebModule.start(WebModule.java:691)
    at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:1041)
    at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:1024)
    at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:747)
    at com.sun.enterprise.web.WebContainer.loadWebModule(WebContainer.java:2286)
    at com.sun.enterprise.web.WebContainer.loadWebModule(WebContainer.java:1932)
    at com.sun.enterprise.web.WebApplication.start(WebApplication.java:139)
    at org.glassfish.internal.data.EngineRef.start(EngineRef.java:122)
    at org.glassfish.internal.data.ModuleInfo.start(ModuleInfo.java:291)
    at org.glassfish.internal.data.ApplicationInfo.start(ApplicationInfo.java:353)
    at com.sun.enterprise.v3.server.ApplicationLifecycle.deploy(ApplicationLifecycle.java:501)
    at com.sun.enterprise.v3.server.ApplicationLifecycle.deploy(ApplicationLifecycle.java:220)
    at org.glassfish.deployment.admin.DeployCommand.execute(DeployCommand.java:487)
    at com.sun.enterprise.v3.admin.CommandRunnerImpl$2$1.run(CommandRunnerImpl.java:539)
    at com.sun.enterprise.v3.admin.CommandRunnerImpl$2$1.run(CommandRunnerImpl.java:535)
    at java.security.AccessController.doPrivileged(Native Method)
    at javax.security.auth.Subject.doAs(Subject.java:356)
    at com.sun.enterprise.v3.admin.CommandRunnerImpl$2.execute(CommandRunnerImpl.java:534)
    at com.sun.enterprise.v3.admin.CommandRunnerImpl$3.run(CommandRunnerImpl.java:565)
    at com.sun.enterprise.v3.admin.CommandRunnerImpl$3.run(CommandRunnerImpl.java:557)
    at java.security.AccessController.doPrivileged(Native Method)
    at javax.security.auth.Subject.doAs(Subject.java:356)
    at com.sun.enterprise.v3.admin.CommandRunnerImpl.doCommand(CommandRunnerImpl.java:556)
    at com.sun.enterprise.v3.admin.CommandRunnerImpl.doCommand(CommandRunnerImpl.java:1464)
    at com.sun.enterprise.v3.admin.CommandRunnerImpl.access$1300(CommandRunnerImpl.java:109)
    at com.sun.enterprise.v3.admin.CommandRunnerImpl$ExecutionContext.execute(CommandRunnerImpl.java:1846)
    at com.sun.enterprise.v3.admin.CommandRunnerImpl$ExecutionContext.execute(CommandRunnerImpl.java:1722)
    at com.sun.enterprise.admin.cli.embeddable.DeployerImpl.deploy(DeployerImpl.java:134)
    at fish.payara.micro.PayaraMicro.deployAll(PayaraMicro.java:1249)
    at fish.payara.micro.PayaraMicro.bootStrap(PayaraMicro.java:905)
    at fish.payara.micro.PayaraMicro.main(PayaraMicro.java:148)
Caused by: java.lang.IllegalArgumentException: Invalid <url-pattern> * in filter mapping
    at org.apache.catalina.core.StandardContext.addFilterMap(StandardContext.java:2910)
    at org.apache.catalina.core.FilterRegistrationImpl.addMappingForUrlPatterns(FilterRegistrationImpl.java:189)
    at org.springframework.boot.context.embedded.AbstractFilterRegistrationBean.configure(AbstractFilterRegistrationBean.java:273)
    at org.springframework.boot.context.embedded.AbstractFilterRegistrationBean.onStartup(AbstractFilterRegistrationBean.java:231)
    at org.springframework.boot.context.embedded.FilterRegistrationBean.onStartup(FilterRegistrationBean.java:41)
    at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext.selfInitialize(EmbeddedWebApplicationContext.java:225)
    at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext.access$000(EmbeddedWebApplicationContext.java:85)
    at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext$1.onStartup(EmbeddedWebApplicationContext.java:209)
    at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext.createEmbeddedServletContainer(EmbeddedWebApplicationContext.java:164)
    at org.springframework.boot.context.embedded.EmbeddedWebApplicationContext.onRefresh(EmbeddedWebApplicationContext.java:130)
    ... 44 common frames omitted`
## **Workaround Available**

create new bean grailsCacheFilter in grails-app/conf/spring/resources.groovy

```
grailsCacheFilter(FilterRegistrationBean) {
        filter = bean(MemoryPageFragmentCachingFilter) {
            cacheManager = ref('grailsCacheManager')
            cacheOperationSource = ref('cacheOperationSource')
            keyGenerator = ref('webCacheKeyGenerator')
            expressionEvaluator = ref('webExpressionEvaluator')
        }
        urlPatterns = "/*"
        dispatcherTypes = EnumSet.of(DispatcherType.FORWARD, DispatcherType.INCLUDE)
    }
```
