### PR TITLE
Cache evict not working with a custom key

### DIFF
--- a/grails-app/controllers/com/demo/DemoController.groovy
+++ b/grails-app/controllers/com/demo/DemoController.groovy
@@ -53,8 +53,20 @@ class DemoController {
 		render "Result: ${result}"
 	}
 
-	def cacheEvict(String key) {
+	def cacheEvictAndGet(String key) {
 		basicCachingService.getDataEvict(key)
+		def result = basicCachingService.getData(key)
+		render "Result: ${result}"
+	}
+
+	def cacheEvictAllAndGet(String key) {
+		basicCachingService.getDataEvictAll()
+		def result = basicCachingService.getData(key)
+		render "Result: ${result}"
+	}
+
+	def cacheClearAndGet(String key) {
+		grailsCacheAdminService.clearCache('basic')
 		def result = basicCachingService.getData(key)
 		render "Result: ${result}"
 	}

--- a/grails-app/controllers/com/demo/DemoController.groovy
+++ b/grails-app/controllers/com/demo/DemoController.groovy
@@ -53,6 +53,12 @@ class DemoController {
 		render "Result: ${result}"
 	}
 
+	def cacheEvict(String key) {
+		basicCachingService.getDataEvict(key)
+		def result = basicCachingService.getData(key)
+		render "Result: ${result}"
+	}
+
 	def blockCache(int counter) {
 		[counter: counter]
 	}

--- a/grails-app/services/com/demo/BasicCachingService.groovy
+++ b/grails-app/services/com/demo/BasicCachingService.groovy
@@ -70,6 +70,10 @@ class BasicCachingService {
     def getDataEvict(String key) {
     }
 
+    @CacheEvict(value = 'basic', allEntries = true)
+    def getDataEvictAll() {
+    }
+
     @Cacheable(value = 'basic', condition = { x < 10 })
     def multiply(int x, int y) {
         conditionalInvocationCounter++

--- a/grails-app/services/com/demo/BasicCachingService.groovy
+++ b/grails-app/services/com/demo/BasicCachingService.groovy
@@ -66,6 +66,10 @@ class BasicCachingService {
         "** ${value} **"
     }
 
+    @CacheEvict(value = 'basic', key = { key } )
+    def getDataEvict(String key) {
+    }
+
     @Cacheable(value = 'basic', condition = { x < 10 })
     def multiply(int x, int y) {
         conditionalInvocationCounter++

--- a/src/ast/groovy/grails/plugin/cache/CustomCacheKeyGenerator.groovy
+++ b/src/ast/groovy/grails/plugin/cache/CustomCacheKeyGenerator.groovy
@@ -81,6 +81,10 @@ class CustomCacheKeyGenerator implements KeyGenerator, GrailsCacheKeyGenerator {
 					return false
 			} else if (!simpleKey.equals(other.simpleKey))
 				return false
+			else if ( simpleKey.equals(other.simpleKey) && !(simpleKey instanceof Map && ((Map)simpleKey).size() == 0 ) ) {
+				return true // equal if simpleKey is identical but not an empty map
+			}
+
 			if (targetClassName == null) {
 				if (other.targetClassName != null)
 					return false
@@ -162,6 +166,10 @@ class CustomCacheKeyGenerator implements KeyGenerator, GrailsCacheKeyGenerator {
 					return false
 			} else if (!simpleKey.equals(other.simpleKey))
 				return false
+			else if ( simpleKey.equals(other.simpleKey) && !(simpleKey instanceof Map && ((Map)simpleKey).size() == 0 ) ) {
+				return true // equal if simpleKey is identical but not an empty map
+			}
+
 			if (targetClassName == null) {
 				if (other.targetClassName != null)
 					return false

--- a/src/ast/groovy/grails/plugin/cache/CustomCacheKeyGenerator.groovy
+++ b/src/ast/groovy/grails/plugin/cache/CustomCacheKeyGenerator.groovy
@@ -39,7 +39,6 @@ class CustomCacheKeyGenerator implements KeyGenerator, GrailsCacheKeyGenerator {
 	}
 
 	@SuppressWarnings("serial")
-	@EqualsAndHashCode
 	private static final class CacheKey implements Serializable {
 		final String targetClassName
 		final String targetMethodName
@@ -52,6 +51,49 @@ class CustomCacheKeyGenerator implements KeyGenerator, GrailsCacheKeyGenerator {
 			this.targetMethodName = targetMethodName
 			this.targetObjectHashCode = targetObjectHashCode
 			this.simpleKey = simpleKey
+		}
+		@Override
+		int hashCode() {
+			final int prime = 31
+			int result = 1
+			result = prime * result
+					+ ((simpleKey == null) ? 0 : simpleKey.hashCode())
+			result = prime * result
+					+ ((targetClassName == null) ? 0 : targetClassName
+							.hashCode())
+			result = prime * result
+					+ ((targetMethodName == null) ? 0 : targetMethodName
+							.hashCode())
+			result = prime * result + targetObjectHashCode
+			return result
+		}
+		@Override
+		boolean equals(Object obj) {
+			if (this.is(obj))
+				return true
+			if (obj == null)
+				return false
+			if (getClass() != obj.getClass())
+				return false
+			CacheKey other = (CacheKey) obj
+			if (simpleKey == null) {
+				if (other.simpleKey != null)
+					return false
+			} else if (!simpleKey.equals(other.simpleKey))
+				return false
+			if (targetClassName == null) {
+				if (other.targetClassName != null)
+					return false
+			} else if (!targetClassName.equals(other.targetClassName))
+				return false
+			if (targetMethodName == null) {
+				if (other.targetMethodName != null)
+					return false
+			} else if (!targetMethodName.equals(other.targetMethodName))
+				return false
+			if (targetObjectHashCode != other.targetObjectHashCode)
+				return false
+			return true
 		}
 	}
 
@@ -77,7 +119,6 @@ class CustomCacheKeyGenerator implements KeyGenerator, GrailsCacheKeyGenerator {
 	}
 
 
-	@EqualsAndHashCode
 	@CompileStatic
 	private static class TemporaryGrailsCacheKey implements Serializable {
 		final String targetClassName
@@ -91,6 +132,49 @@ class CustomCacheKeyGenerator implements KeyGenerator, GrailsCacheKeyGenerator {
 			this.targetMethodName = targetMethodName
 			this.targetObjectHashCode = targetObjectHashCode
 			this.simpleKey = simpleKey
+		}
+		@Override
+		int hashCode() {
+			final int prime = 31
+			int result = 1
+			result = prime * result
+			+ ((simpleKey == null) ? 0 : simpleKey.hashCode())
+			result = prime * result
+			+ ((targetClassName == null) ? 0 : targetClassName
+					.hashCode())
+			result = prime * result
+			+ ((targetMethodName == null) ? 0 : targetMethodName
+					.hashCode())
+			result = prime * result + targetObjectHashCode
+			return result
+		}
+		@Override
+		boolean equals(Object obj) {
+			if (this.is(obj))
+				return true
+			if (obj == null)
+				return false
+			if (getClass() != obj.getClass())
+				return false
+			TemporaryGrailsCacheKey other = (TemporaryGrailsCacheKey) obj
+			if (simpleKey == null) {
+				if (other.simpleKey != null)
+					return false
+			} else if (!simpleKey.equals(other.simpleKey))
+				return false
+			if (targetClassName == null) {
+				if (other.targetClassName != null)
+					return false
+			} else if (!targetClassName.equals(other.targetClassName))
+				return false
+			if (targetMethodName == null) {
+				if (other.targetMethodName != null)
+					return false
+			} else if (!targetMethodName.equals(other.targetMethodName))
+				return false
+			if (targetObjectHashCode != other.targetObjectHashCode)
+				return false
+			return true
 		}
 	}
 

--- a/src/integration-test/groovy/com/demo/CachingServiceIntegrationSpec.groovy
+++ b/src/integration-test/groovy/com/demo/CachingServiceIntegrationSpec.groovy
@@ -2,6 +2,8 @@ package com.demo
 
 import geb.spock.GebSpec
 import grails.test.mixin.integration.Integration
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.cache.CacheManager
 
 @Integration
 class CachingServiceIntegrationSpec extends GebSpec {
@@ -202,13 +204,7 @@ class CachingServiceIntegrationSpec extends GebSpec {
 		browser.driver.pageSource.contains 'Result: ** Thin Lizzy'
 	}
 
-	void 'test basic cache evict service'() {
-		when:
-		go '/demo/cacheGet?key=band'
-
-		then:
-		browser.driver.pageSource.contains 'Result: null'
-
+	void 'test basic cache evict key service'() {
 		when:
 		go '/demo/cachePut?key=band&value=Thin+Lizzy'
 
@@ -216,17 +212,39 @@ class CachingServiceIntegrationSpec extends GebSpec {
 		browser.driver.pageSource.contains 'Result: ** Thin Lizzy **'
 
 		when:
-		go '/demo/cacheGet?key=band'
-
-		then:
-		browser.driver.pageSource.contains 'Result: ** Thin Lizzy'
-
-		when:
-		go '/demo/cacheEvict?key=band'
+		go '/demo/cacheEvictAndGet?key=band'
 
 		then:
 		browser.driver.pageSource.contains 'Result: null'
 	}
+
+    void 'test basic cache evict all service'() {
+        when:
+        go '/demo/cachePut?key=band&value=Thin+Lizzy'
+
+        then:
+        browser.driver.pageSource.contains 'Result: ** Thin Lizzy **'
+
+        when:
+        go '/demo/cacheEvictAllAndGet?key=band'
+
+        then:
+        browser.driver.pageSource.contains 'Result: null'
+    }
+
+    void 'test basic cache clear service'() {
+        when:
+        go '/demo/cachePut?key=band&value=Thin+Lizzy'
+
+        then:
+        browser.driver.pageSource.contains 'Result: ** Thin Lizzy **'
+
+        when:
+        go '/demo/cacheClearAndGet?key=band'
+
+        then:
+        browser.driver.pageSource.contains 'Result: null'
+    }
 
 
 

--- a/src/integration-test/groovy/com/demo/CachingServiceIntegrationSpec.groovy
+++ b/src/integration-test/groovy/com/demo/CachingServiceIntegrationSpec.groovy
@@ -201,4 +201,33 @@ class CachingServiceIntegrationSpec extends GebSpec {
 		then:
 		browser.driver.pageSource.contains 'Result: ** Thin Lizzy'
 	}
+
+	void 'test basic cache evict service'() {
+		when:
+		go '/demo/cacheGet?key=band'
+
+		then:
+		browser.driver.pageSource.contains 'Result: null'
+
+		when:
+		go '/demo/cachePut?key=band&value=Thin+Lizzy'
+
+		then:
+		browser.driver.pageSource.contains 'Result: ** Thin Lizzy **'
+
+		when:
+		go '/demo/cacheGet?key=band'
+
+		then:
+		browser.driver.pageSource.contains 'Result: ** Thin Lizzy'
+
+		when:
+		go '/demo/cacheEvict?key=band'
+
+		then:
+		browser.driver.pageSource.contains 'Result: null'
+	}
+
+
+
 }


### PR DESCRIPTION
Caching and eviction does not work with the following example:

```
@Cacheable(value = 'basic', key = { key })
def doSomething(String key)  { ... }
@CacheEvict(value = 'basic', key = { key } )
def evictCache(String key) { .. }
```

According to my checks the problem is the`@EqualsAndHashCode` annotation creates a comparison where the method name is also part of the key. Therefore tha evict call cannot invalidate a cache entry.
The old manual implementation causes the same problem.
Therefore I modified the old manual implementation to skip the method name comparison if the provided keys are identical.
This is not a very nice solution but it solved the problem in my use cases. 
A improved implementation might be tested using the added integration tests.

