### PR TITLE
try to update to openjdk8 to support EC crypto

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache:
   directories:
   - "$HOME/.gradle"
 jdk:
-- openjdk7
+- openjdk8
 before_script:
 - rm -rf target
 script: ./travis-build.sh

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,9 @@ apply plugin:"org.grails.grails-plugin"
 apply plugin:"org.grails.grails-plugin-publish"
 apply from:"https://raw.githubusercontent.com/grails/grails-common-build/master/common-docs.gradle"
 
+sourceCompatibility = 1.7
+targetCompatibility = 1.7
+
 repositories {
     mavenLocal()
     maven { url "https://repo.grails.org/grails/core" }


### PR DESCRIPTION
Travis build fails with `Exception in thread "main" javax.net.ssl.SSLException: java.security.ProviderException: java.security.InvalidKeyException: EC parameters error`

The gradle server probably changed the crypt settings to a mode OpenJDK 7 does not support. A upgrade to OpenJDK 8 could solve the problem because it shipts these methods.