### PR TITLE
Workaround for error in groovydoc task (#53)

### DIFF
--- a/src/main/groovy/grails/plugin/cache/GrailsConcurrentLinkedMapCache.java
+++ b/src/main/groovy/grails/plugin/cache/GrailsConcurrentLinkedMapCache.java
@@ -44,7 +44,9 @@ public class GrailsConcurrentLinkedMapCache implements GrailsCache {
       this.name = name;
       this.capacity = capacity;
       this.allowNullValues = allowNullValues;
-      this.store = new ConcurrentLinkedHashMap.Builder<>()
+      // Workaround: using explicit type arguments to prevent groovydoc error (#53)
+      // Replace with diamond operator once a fix for GROOVY-8628 is included in groovy dependency
+      this.store = new ConcurrentLinkedHashMap.Builder<Object, Object>()
          .maximumWeightedCapacity(capacity)
          .build();
    }


### PR DESCRIPTION
* Prevent groovydoc error by using explicit type arguments instead of
  diamond operator
* Revert once a fix for [GROOVY-8628](https://issues.apache.org/jira/browse/GROOVY-8628) is included in groovy dependency