### PR TITLE
Made CacheConfig inner class of CachePluginConfiguration a nested (st…

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -69,3 +69,14 @@ grails:
 endpoints:
     jmx:
         unique-names: true
+---
+environments:
+    test:
+        grails:
+            cache:
+                cacheManager: GrailsConcurrentLinkedMapCacheManager
+                caches:
+                    foo:
+                        maxCapacity: 100
+                    bar:
+                        maxCapacity: 200

--- a/src/integration-test/groovy/com/demo/MaxCapacityCacheSpec.groovy
+++ b/src/integration-test/groovy/com/demo/MaxCapacityCacheSpec.groovy
@@ -1,0 +1,32 @@
+package com.demo
+
+import grails.plugin.cache.GrailsConcurrentLinkedMapCache
+import grails.plugin.cache.GrailsConcurrentLinkedMapCacheManager
+import grails.testing.mixin.integration.Integration
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * This test case validates the documented cache configuration behavior and fix for
+ * issue https://github.com/grails-plugins/grails-cache/issues/62
+ */
+@Integration
+class MaxCapacityCacheSpec extends Specification {
+
+    GrailsConcurrentLinkedMapCacheManager grailsCacheManager
+
+    @Unroll
+    void "Verify max capacities set for configured caches"() {
+        when:
+            GrailsConcurrentLinkedMapCache cache = grailsCacheManager.getCache(cacheName) as GrailsConcurrentLinkedMapCache
+
+        then:
+            cache.capacity == expectedCapacity
+
+        where:
+            cacheName | expectedCapacity
+            'foo'     | 100
+            'bar'     | 200
+
+    }
+}

--- a/src/main/groovy/grails/plugin/cache/CachePluginConfiguration.groovy
+++ b/src/main/groovy/grails/plugin/cache/CachePluginConfiguration.groovy
@@ -16,7 +16,7 @@ class CachePluginConfiguration {
     Boolean clearAtStartup = false
     Map<String, CacheConfig> caches = [:]
 
-    class CacheConfig {
+    static class CacheConfig {
         Integer maxCapacity
     }
 }


### PR DESCRIPTION
Fix for [Issue 62](https://github.com/grails-plugins/grails-cache/issues/62). Needed to make CacheConfig inner class of CachePluginConfiguration a nested (static) class. Added an integration spec to verify issue was resolved.