### PR TITLE
exclude unnecessary files from jar artifact

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ buildscript {
     }
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsVersion"
-        classpath "com.bertramlabs.plugins:asset-pipeline-gradle:3.2.5"
         classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.6.1'
         classpath "gradle.plugin.com.github.erdi.webdriver-binaries:webdriver-binaries-gradle-plugin:$webdriverBinariesVersion"
     }
@@ -17,8 +16,6 @@ apply plugin:"eclipse"
 apply plugin:"idea"
 apply plugin:"org.grails.grails-plugin"
 apply plugin:"org.grails.grails-plugin-publish"
-apply plugin:"asset-pipeline"
-apply plugin:"org.grails.grails-gsp"
 apply from:"https://raw.githubusercontent.com/grails/grails-common-build/v1.0.0/common-docs.gradle"
 apply plugin: "com.github.erdi.webdriver-binaries"
 
@@ -120,13 +117,14 @@ grailsPublish {
     developers = [jeffbrown: "Jeff Scott Brown"]
 }
 
-
-assets {
-    packagePlugin = true
-}
-
 integrationTest {
     testLogging {
         exceptionFormat = 'full'
     }
+}
+
+// exclude demo code from jar artifact
+jar {
+    includeEmptyDirs = false
+    exclude 'com/demo/**'
 }

--- a/src/main/groovy/grails/plugin/cache/CacheGrailsPlugin.groovy
+++ b/src/main/groovy/grails/plugin/cache/CacheGrailsPlugin.groovy
@@ -30,14 +30,6 @@ class CacheGrailsPlugin extends Plugin {
     def authorEmail = 'brownj@objectcomputing.com'
     def description = 'Grails Cache Plugin'
 
-    // resources that should be loaded by the plugin once installed in the application
-    //Does this even work anymore?  Doesn't appear to.
-    def pluginExcludes = [
-            '**/com/demo/**',
-            'grails-app/views/**',
-            '**/*.gsp'
-    ]
-
     private boolean isCachingEnabled() {
         config.getProperty('grails.cache.enabled', Boolean, true)
     }


### PR DESCRIPTION
When we upgraded some of our applications to Grails 4.x we had some problems with the loading of views and layouts, which we had to debug and managed to track back to this plugin. The reason was that the views (notFound.gsp, main.gsp) contained in the distribution of this plugin were discovered before those in our own plugins. We managed to work around it by defining `def loadAfter = ['cache']` in our own plugins.

Nevertheless, I think this plugin should not include stuff that is not needed by or does even break the consuming application. To address this, I made the following changes:

- remove asset-pipeline from the gradle build as the plugin doesn't provide any assets itself and therefore no unnecessary files are generated by the asset-pipeline gradle plugin
- remove grails-gsp from the gradle build to prevent the compiled GSPs from being added to the artifact (they are only used for demo and testing purposes when the plugin is run locally)
- remove `pluginExcludes` from the `CacheGrailsPlugin` class as this is not working anymore since Grails 3.x I think
- exclude demo content from the generated artifact using gradle