### PR TITLE
Fix key generator hash code

### DIFF
--- a/src/ast/groovy/grails/plugin/cache/CustomCacheKeyGenerator.groovy
+++ b/src/ast/groovy/grails/plugin/cache/CustomCacheKeyGenerator.groovy
@@ -55,14 +55,9 @@ class CustomCacheKeyGenerator implements KeyGenerator, GrailsCacheKeyGenerator {
 		int hashCode() {
 			final int prime = 31
 			int result = 1
-			result = prime * result
-					+ ((simpleKey == null) ? 0 : simpleKey.hashCode())
-			result = prime * result
-					+ ((targetClassName == null) ? 0 : targetClassName
-							.hashCode())
-			result = prime * result
-					+ ((targetMethodName == null) ? 0 : targetMethodName
-							.hashCode())
+			result = prime * result + ((simpleKey == null) ? 0 : simpleKey.hashCode())
+			result = prime * result + ((targetClassName == null) ? 0 : targetClassName.hashCode())
+			result = prime * result + ((targetMethodName == null) ? 0 : targetMethodName.hashCode())
 			result = prime * result + targetObjectHashCode
 			return result
 		}
@@ -140,14 +135,9 @@ class CustomCacheKeyGenerator implements KeyGenerator, GrailsCacheKeyGenerator {
 		int hashCode() {
 			final int prime = 31
 			int result = 1
-			result = prime * result
-			+ ((simpleKey == null) ? 0 : simpleKey.hashCode())
-			result = prime * result
-			+ ((targetClassName == null) ? 0 : targetClassName
-					.hashCode())
-			result = prime * result
-			+ ((targetMethodName == null) ? 0 : targetMethodName
-					.hashCode())
+			result = prime * result + ((simpleKey == null) ? 0 : simpleKey.hashCode())
+			result = prime * result + ((targetClassName == null) ? 0 : targetClassName.hashCode())
+			result = prime * result + ((targetMethodName == null) ? 0 : targetMethodName.hashCode())
 			result = prime * result + targetObjectHashCode
 			return result
 		}

--- a/src/test/groovy/grails/plugin/cache/CustomCacheKeyGeneratorSpec.groovy
+++ b/src/test/groovy/grails/plugin/cache/CustomCacheKeyGeneratorSpec.groovy
@@ -1,0 +1,41 @@
+package grails.plugin.cache
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class CustomCacheKeyGeneratorSpec extends Specification {
+
+    void 'test matching keys'() {
+
+        given:
+        CustomCacheKeyGenerator keyGenerator = new CustomCacheKeyGenerator()
+
+        when:
+        Serializable key1 = keyGenerator.generate('TestService', 'method', 0, [ arg1: 1, arg2: 2 ])
+        Serializable key2 = keyGenerator.generate('TestService', 'method', 0, [ arg1: 1, arg2: 2 ])
+
+        then:
+        key1.hashCode() == key2.hashCode()
+    }
+
+    @Unroll('#className::#methodName(#params) should not match TestService::method([arg1: 1, arg2: 2])')
+    void 'test differing keys'() {
+
+        given:
+        CustomCacheKeyGenerator keyGenerator = new CustomCacheKeyGenerator()
+        Serializable key1 = keyGenerator.generate('TestService', 'method', 0, [ arg1: 1, arg2: 2 ])
+
+        when:
+        Serializable key2 = keyGenerator.generate(className, methodName, 0, params)
+
+        then:
+        key1.hashCode() != key2.hashCode()
+
+        where:
+        className | methodName | params
+        'TestService' | 'method' | [ arg1: 1, arg2: 3 ]
+        'TestService' | 'method' | [ arg1: 1, _arg2: 2 ]
+        'TestService' | '_method' | [ arg1: 1, arg2: 2 ]
+        '_TestService' | 'method' | [ arg1: 1, arg2: 2 ]
+    }
+}


### PR DESCRIPTION
fixed code formatting of the `KeyGenerator::hasCode` which resulted in an incorrect interpretation then compiling to bytecode. 

Unit test for `CustomCacheKeyGenerator`

Fixes apache/grails-core#14165 