### PR TITLE
Don't hard-code the "geb.env" system property

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ webdriverBinaries {
 }
 
 tasks.withType(Test) {
-    systemProperty "geb.env", "chromeHeadless"
+    systemProperty "geb.env", System.getProperty('geb.env', 'chromeHeadless')
     systemProperty "geb.build.reportsDir", reporting.file("geb/integrationTest")
 
     if (!System.getenv().containsKey('GITHUB_ACTIONS')) {


### PR DESCRIPTION
Otherwise it is not possible to set it on the commandline.