### PR TITLE
chore(build): only publish build scans for CI

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ plugins {
 gradleEnterprise {
     server = 'https://ge.grails.org'
     buildScan {
-        publishAlways()
+        publishAlwaysIf(System.getenv('CI') == 'true')
         publishIfAuthenticated()
         uploadInBackground = System.getenv("CI") == null
         capture {


### PR DESCRIPTION
Update the gradleEnterprise configurations in the `settings.gradle` file by changing the `publishAlways` to `publishAlwaysIf`.