### PR TITLE
chore(ci): update java-ci workflow configurations

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       WORKSPACE: ${{ github.workspace }}
       GRADLE_OPTS: -Xmx1500m -Dfile.encoding=UTF-8
@@ -19,18 +21,9 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'adopt'
-          java-version: 8
-      - name: Run Tests
-        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
-        id: tests
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: check -Dgeb.env=chromeHeadless
-        env:
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
+          java-version: '8'
       - name: Run Build
-        if: github.event_name == 'push'
+        if: success()
         id: build
         uses: gradle/gradle-build-action@v3
         env:
@@ -39,35 +32,69 @@ jobs:
           GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         with:
           arguments: build -Dgeb.env=chromeHeadless
-      - name: Publish Test Report
-        if: steps.build.outcome == 'failure' || steps.tests.outcome == 'failure'
-        uses: scacap/action-surefire-report@v1
+      - name: Upload Distribution
+        if: success()
+        uses: actions/upload-artifact@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: '**/build/test-results/test/TEST-*.xml'
+          name: grails-gsp-SNAPSHOT
+          path: ./**/build/libs/*
+  publish:
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: '8'
       - name: Publish to repo.grails.org
         id: publish
         uses: gradle/gradle-build-action@v3
-        if: steps.build.outcome == 'success' && github.event_name == 'push'
+        if: success()
         env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
         with:
           arguments: -Dorg.gradle.internal.publish.checksums.insecure=true publish
+  docs:
+    if: github.event_name == 'push' && false # disabled due to Gradle problem with PublishGuide task. Remove after Grails 5.3.7 release.
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'adopt'
+          java-version: '8'
       - name: Build Docs
         id: docs
-        if: steps.build.outcome == 'success' && github.event_name == 'push'
+        if: success()
         uses: gradle/gradle-build-action@v3
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
+          GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         with:
           arguments: docs
       - name: Publish to Github Pages
-        if: steps.docs.outcome == 'success' && github.event_name == 'push'
-        uses: micronaut-projects/github-pages-deploy-action@master
+        if: success()
+        uses: grails/github-pages-deploy-action@v2
         env:
+          SKIP_SNAPSHOT: true
           TARGET_REPOSITORY: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           BRANCH: gh-pages
           FOLDER: build/docs
           DOC_FOLDER: gh-pages
-          COMMIT_EMAIL: behlp@objectcomputing.com
+          COMMIT_EMAIL: behlp@unityfoundation.io
           COMMIT_NAME: Puneet Behl

--- a/gradle/docs.gradle
+++ b/gradle/docs.gradle
@@ -60,6 +60,6 @@ task docs(dependsOn:[groovydoc, publishGuide]) {
     group = 'documentation'
 }
 
-tasks.named("build") {
-    finalizedBy("docs")
-}
+//tasks.named("build") {
+//    finalizedBy("docs")
+//}


### PR DESCRIPTION
* Breakdown into multiple jobs
* Disable publish docs job because of the problem with PublishGuide::macro has conflicting annotation.
* Configure Gradle Enterprise secrets for the required steps.
* Improve workflow configurations