### PR TITLE
chore(ci): update release workflow configurations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           arguments: | 
             -Psigning.secretKeyRingFile=${{ github.workspace }}/secring.gpg 
             publishToSonatype 
-            closeAndReleaseSonatypeStagingRepository
+            closeSonatypeStagingRepository
   release:
     needs: publish
     runs-on: ubuntu-latest


### PR DESCRIPTION
Update publish job to only `closeSonatypeStagingRepository`.