### PR TITLE
Fix: Ignore @Cacheable Annotation on Controller Methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ grails-app/conf/BootStrap.groovy
 grails-app/conf/spring/
 grails-app/views/error.gsp
 grails-app/views/index.gsp
+bin/

--- a/grails-app/controllers/com/demo/DemoController.groovy
+++ b/grails-app/controllers/com/demo/DemoController.groovy
@@ -1,10 +1,17 @@
 package com.demo
 
+import grails.plugin.cache.Cacheable
+
 class DemoController {
 
 	def basicCachingService
 	def grailsCacheAdminService
 
+	@Cacheable('show')
+	def show (params) {
+		return [param: params.id]
+	}
+	
 	def clearBlocksCache() {
 		grailsCacheAdminService.clearBlocksCache()
 		render "cleared blocks cache"

--- a/grails-app/views/demo/show.gsp
+++ b/grails-app/views/demo/show.gsp
@@ -1,0 +1,1 @@
+Hello World!${param}

--- a/src/ast/groovy/org/grails/plugin/cache/compiler/CacheableTransformation.groovy
+++ b/src/ast/groovy/org/grails/plugin/cache/compiler/CacheableTransformation.groovy
@@ -55,6 +55,13 @@ class CacheableTransformation extends AbstractCacheTransformation {
     @Override
     protected Expression buildDelegatingMethodCall(SourceUnit sourceUnit, AnnotationNode annotationNode, ClassNode classNode, MethodNode methodNode, MethodCallExpression originalMethodCallExpr, BlockStatement newMethodBody) {
 
+        boolean isControllerClass = classNode.name.endsWith('Controller')
+        boolean isServiceClass = classNode.name.endsWith('Service')
+
+        if (isControllerClass && !isServiceClass) {
+            return originalMethodCallExpr
+        }
+
         VariableExpression cacheManagerVariableExpression = varX(GRAILS_CACHE_MANAGER_PROPERTY_NAME)
         handleCacheCondition(sourceUnit, annotationNode,  methodNode, originalMethodCallExpr, newMethodBody)
 

--- a/src/integration-test/groovy/com/demo/NotCachingControllerIntegrationSpec.groovy
+++ b/src/integration-test/groovy/com/demo/NotCachingControllerIntegrationSpec.groovy
@@ -1,0 +1,22 @@
+package com.demo
+
+import geb.spock.GebSpec
+import grails.testing.mixin.integration.Integration
+
+@Integration
+class NotCachingControllerIntegrationSpec extends GebSpec {
+
+    void 'test action controller with different parameters'() {
+        when:
+        go '/demo/show/1'
+
+        then:
+        $().text().contains 'Hello World!1'
+
+        when:
+        go '/demo/show/2'
+
+        then:
+        $().text().contains 'Hello World!2'
+    }
+}


### PR DESCRIPTION
**Related Issue:**
This PR addresses the issue described in https://github.com/grails/grails-cache/issues/168

**Summary**
This PR addresses an issue where the `@Cacheable` annotation on controller methods does not behave as expected in plugin version 4.0.0. Instead of ignoring the annotation, the method is executed only the first time as if it were being cached, causing inconsistencies when the controller action receives parameters.

**Solution**
To solve this issue, I have modified the buildDelegatingMethodCall method to check if the class is a controller and not a service. If it is a controller, the original method call is returned, effectively ignoring the `@Cacheable` annotation.

Here is the relevant code snippet:
```groovy
@Override
protected Expression buildDelegatingMethodCall(SourceUnit sourceUnit, AnnotationNode annotationNode, ClassNode classNode, MethodNode methodNode, MethodCallExpression originalMethodCallExpr, BlockStatement newMethodBody) {
    boolean isControllerClass = classNode.name.endsWith("Controller")
    boolean isServiceClass = classNode.name.endsWith("Service")

    if (isControllerClass && !isServiceClass) {
        return originalMethodCallExpr
    }

    // Existing logic for handling caching
}
```

**Reason for Targeting the 4.x Branch**
I am submitting this change to the 4.x branch because I encountered this issue when migrating from Grails 2.5.6 to Grails 3.3.11, where I started using version 4 of the cache plugin.